### PR TITLE
feat:(parser) adds support for optional emojis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,9 @@ try {
 }
 
 var parserOpts = {
-  headerPattern: /^(\w*)(?:\((.*)\))?\: (.*)$/,
+  headerPattern: /^(?::\w*:\s)?(\w*)(?:\((.*)\))?\: (.*)$/,
   headerCorrespondence: [
+    'emoji',
     'type',
     'scope',
     'subject'


### PR DESCRIPTION
Emojis are visible in commit messages since this commit https://github.com/ellerbrock/cz-conventional-changelog-emoji/commit/54a3df726a7815e01f838e6694e5257e8546024b but the parser is not able to generate the changelog.